### PR TITLE
メモ詳細ページのレスポンシブ対応。ページ下部で記事のランダム表示も行う。

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -38,7 +38,7 @@ const routes: Routes = [
   },
   {
     path: 'memo',
-    loadChildren: () => import('./memo/memo.module').then((m) => m.MemoModule),
+    loadChildren: () => import('./user-shell/user-shell.module').then((m) => m.UserShellModule),
   },
   {
     path: '404',

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -9,7 +9,8 @@ const routes: Routes = [
   },
   {
     path: '',
-    loadChildren: () => import('./user-shell/user-shell.module').then((m) => m.UserShellModule),
+    loadChildren: () =>
+      import('./user-shell/user-shell.module').then((m) => m.UserShellModule),
   },
   {
     path: 'enter',
@@ -38,7 +39,8 @@ const routes: Routes = [
   },
   {
     path: 'memo',
-    loadChildren: () => import('./user-shell/user-shell.module').then((m) => m.UserShellModule),
+    loadChildren: () =>
+      import('./user-shell/user-shell.module').then((m) => m.UserShellModule),
   },
   {
     path: '404',
@@ -63,7 +65,8 @@ const routes: Routes = [
   {
     path: '',
     pathMatch: 'full',
-    loadChildren: () => import('./user-shell/user-shell.module').then((m) => m.UserShellModule),
+    loadChildren: () =>
+      import('./user-shell/user-shell.module').then((m) => m.UserShellModule),
   },
   {
     path: 'transaction-law',
@@ -84,7 +87,12 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [
+    RouterModule.forRoot(routes, {
+      scrollPositionRestoration: 'enabled',
+      anchorScrolling: 'enabled', // 画面表示時のアンカーリンクを有効にする
+    }),
+  ],
   exports: [RouterModule],
 })
 export class AppRoutingModule {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { AngularFireAnalyticsModule } from '@angular/fire/analytics';
 import { AngularFirestoreModule } from '@angular/fire/firestore';
 import { AngularFireStorageModule } from '@angular/fire/storage';
 import { AngularFireFunctionsModule, REGION } from '@angular/fire/functions';
+import { SharedModule } from './shared/shared.module';
 
 @NgModule({
   declarations: [AppComponent],
@@ -25,7 +26,7 @@ import { AngularFireFunctionsModule, REGION } from '@angular/fire/functions';
     AngularFireAnalyticsModule,
     AngularFirestoreModule,
     AngularFireFunctionsModule,
-    AngularFireStorageModule
+    AngularFireStorageModule,
   ],
   providers: [
     { provide: REGION, useValue: 'asia-northeast1' }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -27,10 +27,9 @@ import { SharedModule } from './shared/shared.module';
     AngularFirestoreModule,
     AngularFireFunctionsModule,
     AngularFireStorageModule,
+    SharedModule,
   ],
-  providers: [
-    { provide: REGION, useValue: 'asia-northeast1' }
-  ],
+  providers: [{ provide: REGION, useValue: 'asia-northeast1' }],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/src/app/author/author.component.html
+++ b/src/app/author/author.component.html
@@ -1,59 +1,61 @@
-<div class="profile-card">
-  <div class="profile-box">
-    <div class="profile-card__top">
-      <div class="profile-card__user">
-        <img src="assets/images/profile-image-example.jpg" alt="" />
-      </div>
-      <div>
-        <p class="profile-card__name">Username</p>
-        <p class="profile-card__subject">Subject</p>
-        <div class="icons-box">
-          <img
-            class="profile-card__socials"
-            src="assets/images/twitter.svg"
-            alt=""
-          />
-          <img
-            class="profile-card__socials"
-            src="assets/images/youtube-brands.svg"
-            alt=""
-          />
-          <img
-            class="profile-card__socials"
-            src="assets/images/soundcloud-brands.svg"
-            alt=""
-          />
-          <img
-            class="profile-card__socials"
-            src="assets/images/icons/round-link.svg"
-            alt=""
-          />
+<ng-container *ngIf="user$ | async as user">
+  <div class="profile-card">
+    <div class="profile-box">
+      <div class="profile-card__top">
+        <div class="profile-card__user">
+          <img src="{{user.avatarURL}}" alt="" />
+        </div>
+        <div>
+          <p class="profile-card__name">{{ user.name }}</p>
+          <p class="profile-card__subject">Subject</p>
+          <div class="icons-box">
+            <img
+              class="profile-card__socials"
+              src="assets/images/twitter.svg"
+              alt=""
+            />
+            <img
+              class="profile-card__socials"
+              src="assets/images/youtube-brands.svg"
+              alt=""
+            />
+            <img
+              class="profile-card__socials"
+              src="assets/images/soundcloud-brands.svg"
+              alt=""
+            />
+            <img
+              class="profile-card__socials"
+              src="assets/images/icons/round-link.svg"
+              alt=""
+            />
 
-          <div class="follow-box">
-            <button class="profile-card__text">
-              <img src="assets/images/icons/round-add.svg" alt="" />Follow
-            </button>
+            <div class="follow-box">
+              <button class="profile-card__text">
+                <img src="assets/images/icons/round-add.svg" alt="" />Follow
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="profile-card__profile">
+        <p>
+          プロフィールテキストプロフィールテキストプロフィールテキストプロフィールテキストプロフィールテキストプロフィールテキストプロフィールテキスト
+        </p>
+      </div>
+
+      <div class="support-container">
+        <div class="support-card">
+          <div class="">
+            <h3>クリエイターを応援しよう</h3>
+            <p>{{ user.name }}さんへの知見の対価としてお金を支払うことができます。</p>
+            <div class="button button--support">サポートする</div>
+          </div>
+          <div class="">
+            <img src="assets/images/support-image.svg" alt="" />
           </div>
         </div>
       </div>
     </div>
-    <div class="profile-card__profile">
-      <p>
-        プロフィールテキストプロフィールテキストプロフィールテキストプロフィールテキストプロフィールテキストプロフィールテキストプロフィールテキスト
-      </p>
-    </div>
-
-    <div class="support-container">
-      <div class="support-card">
-        <div class="">
-          <h3>クリエイターを応援しよう</h3>
-          <p>Userさんへの知見の対価としてお金を支払うことができます。</p>
-          <div class="button button--support">サポートする</div>
-        </div>
-        <div class="">
-          <img src="assets/images/support-image.svg" alt="" />
-        </div>
-      </div>
-    </div>
   </div>
-</div>
+</ng-container>

--- a/src/app/author/author.component.scss
+++ b/src/app/author/author.component.scss
@@ -1,8 +1,12 @@
+@import 'mixins';
 .profile-card {
   max-width: 1338px;
   box-shadow: 6px 6px 12px #b8b9be, -6px -6px 12px #ffffff;
   border-radius: 8px;
   margin-bottom: 40px;
+  @include sm {
+    max-width: 343px;
+  }
   &__top {
     display: flex;
     margin-bottom: 24px;
@@ -83,6 +87,21 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
+  @include sm {
+    padding: 12px 24px;
+    margin: 0 auto;
+    text-align: center;
+  }
+  & h3 {
+    @include sm {
+      font-size: 16px;
+    }
+  }
+  & img {
+    @include sm {
+      display: none;
+    }
+  }
   p {
     margin-bottom: 8px;
     font-size: 12px;

--- a/src/app/author/author.component.ts
+++ b/src/app/author/author.component.ts
@@ -1,15 +1,33 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { Memo } from '../interfaces/memo';
+import { AuthService } from '../services/auth.service';
+import { MemoService } from '../services/memo.service';
 
 @Component({
   selector: 'app-author',
   templateUrl: './author.component.html',
-  styleUrls: ['./author.component.scss']
+  styleUrls: ['./author.component.scss'],
 })
 export class AuthorComponent implements OnInit {
-
-  constructor() { }
+  memoId: string; // MemoServisでmemoIdからMemoをとってくる memoIdのいれもの
+  memo$: Observable<Memo>;
+  user$ = this.authService.user$; // userをauthServiceのuser$と定義
+  constructor(
+    private authService: AuthService,
+    private route: ActivatedRoute,
+    private memoService: MemoService
+  ) {}
 
   ngOnInit(): void {
+    this.memo$ = this.route.paramMap.pipe(
+      switchMap((param) => {
+        const id = param.get('id');
+        this.memoId = id;
+        return this.memoService.getMemo(id);
+      })
+    );
   }
-
 }

--- a/src/app/category-card/category-card.component.html
+++ b/src/app/category-card/category-card.component.html
@@ -1,18 +1,19 @@
+<ng-container *ngIf="memo$ | async as memo">
 <div class="category-card">
   <div class="category-box">
     <p class="category-card__title">category</p>
     <div class="category-grid">
       <div class="category-flex">
         <img src="assets/images/category-example.jpg" alt="" />
-        <p>Category1</p>
+        <p>{{memo.categories[0]}}</p>
       </div>
       <div class="category-flex">
         <img src="assets/images/category-example.jpg" alt="" />
-        <p>Category2</p>
+        <p>{{memo.categories[1]}}</p>
       </div>
       <div class="category-flex">
         <img src="assets/images/category-example.jpg" alt="" />
-        <p>Category3</p>
+        <p>{{memo.categories[2]}}</p>
       </div>
       <div class="category-flex">
         <img src="assets/images/category-example.jpg" alt="" />
@@ -21,3 +22,4 @@
     </div>
   </div>
 </div>
+</ng-container>

--- a/src/app/category-card/category-card.component.ts
+++ b/src/app/category-card/category-card.component.ts
@@ -1,15 +1,22 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { Memo } from '../interfaces/memo';
+import { MemoService } from '../services/memo.service';
 
 @Component({
   selector: 'app-category-card',
   templateUrl: './category-card.component.html',
-  styleUrls: ['./category-card.component.scss']
+  styleUrls: ['./category-card.component.scss'],
 })
 export class CategoryCardComponent implements OnInit {
+  memoId: string;
+  memo$: Observable<Memo>;
+  constructor(
+    private route: ActivatedRoute,
+    private memoService: MemoService
+  ) {}
 
-  constructor() { }
-
-  ngOnInit(): void {
-  }
-
+  ngOnInit(): void {}
 }

--- a/src/app/category-card/category-card.component.ts
+++ b/src/app/category-card/category-card.component.ts
@@ -18,5 +18,13 @@ export class CategoryCardComponent implements OnInit {
     private memoService: MemoService
   ) {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.memo$ = this.route.paramMap.pipe(
+      switchMap((param) => {
+        const id = param.get('id');
+        this.memoId = id;
+        return this.memoService.getMemo(id);
+      })
+    );
+  }
 }

--- a/src/app/coments/coments.component.html
+++ b/src/app/coments/coments.component.html
@@ -21,7 +21,7 @@
       </p>
     </div>
     <div class="coment-card__buttons">
-      <img src="assets/images/favorite.svg" alt="" />
+      <img (click)="like()" src="assets/images/favorite.svg" alt="" />
       <img src="assets/images/icons/coment-image.svg" alt="" />
     </div>
     <div class="coment-card__response">

--- a/src/app/coments/coments.component.ts
+++ b/src/app/coments/coments.component.ts
@@ -3,13 +3,13 @@ import { Component, OnInit } from '@angular/core';
 @Component({
   selector: 'app-coments',
   templateUrl: './coments.component.html',
-  styleUrls: ['./coments.component.scss']
+  styleUrls: ['./coments.component.scss'],
 })
 export class ComentsComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit(): void {
+  ngOnInit(): void {}
+  like(): void {
+    alert('like!');
   }
-
 }

--- a/src/app/detail-header/detail-header.component.html
+++ b/src/app/detail-header/detail-header.component.html
@@ -18,9 +18,9 @@
             <p>{{ memo.categories[2] }}</p>
           </div>
           <div class="icons">
-            <div class="recent-posted-card__card-button">
+            <div class="recent-posted-card__card-button" (click)="like()">
               <img src="assets/images/favorite.svg" alt="" />
-              <p>123</p>
+              <p>{{ memo.likeCount }}</p>
             </div>
             <div>
               <a href="https://twitter.com/home" target="blank">

--- a/src/app/detail-header/detail-header.component.html
+++ b/src/app/detail-header/detail-header.component.html
@@ -1,24 +1,28 @@
 <div class="wrapper">
   <div class="container">
-    <h1>メモタイトル</h1>
-    <div class="memo-category">
-      <p>2020年12月2日</p>
-      <p>カテゴリ1</p>
-      <p>カテゴリ2</p>
-      <p>カテゴリ3</p>
-    </div>
-    <div class="icons">
-      <div class="recent-posted-card__card-button">
-        <img src="assets/images/favorite.svg" alt="" />
-        <p>123</p>
+    <!-- <button (click)="getMemo()"></button> -->
+    <ng-container *ngIf="memo$ | async as memo">
+      <!-- ここでmemo.を使うために、上の行でmemo$をmemoとして扱う記述をする -->
+      <h1>{{memo.title}}</h1>
+      <div class="memo-category">
+        <p>2020年12月2日</p>
+        <p>カテゴリ1</p>
+        <p>カテゴリ2</p>
+        <p>カテゴリ3</p>
       </div>
-      <div>
-        <img
-          class="button button--small-social"
-          src="assets/images/twitter.svg"
-          alt=""
-        />
+      <div class="icons">
+        <div class="recent-posted-card__card-button">
+          <img src="assets/images/favorite.svg" alt="" />
+          <p>123</p>
+        </div>
+        <div>
+          <img
+            class="button button--small-social"
+            src="assets/images/twitter.svg"
+            alt=""
+          />
+        </div>
       </div>
-    </div>
+    </ng-container>
   </div>
 </div>

--- a/src/app/detail-header/detail-header.component.html
+++ b/src/app/detail-header/detail-header.component.html
@@ -1,28 +1,39 @@
-<div class="wrapper">
-  <div class="container">
-    <!-- <button (click)="getMemo()"></button> -->
-    <ng-container *ngIf="memo$ | async as memo">
-      <!-- ここでmemo.を使うために、上の行でmemo$をmemoとして扱う記述をする -->
-      <h1>{{memo.title}}</h1>
-      <div class="memo-category">
-        <p>2020年12月2日</p>
-        <p>カテゴリ1</p>
-        <p>カテゴリ2</p>
-        <p>カテゴリ3</p>
-      </div>
-      <div class="icons">
-        <div class="recent-posted-card__card-button">
-          <img src="assets/images/favorite.svg" alt="" />
-          <p>123</p>
+<ng-container *ngIf="memo$ | async as memo">
+  <div class="wrapper">
+    <div class="container container--memo-header">
+      <div class="memo-header">
+        <img
+          class="memo-header__thumbnail"
+          src="{{ memo.thumbnailUrl }}"
+          alt=""
+        />
+        <!-- <button (click)="getMemo()"></button> -->
+        <!-- ここでmemo.を使うために、上の行でmemo$をmemoとして扱う記述をする -->
+        <div class="memo-header__contents">
+          <h1>{{ memo.title }}</h1>
+          <div class="memo-category">
+            <p>{{ memo.createdAt.toDate() | date: 'yyyy/MM/dd' }}</p>
+            <p>{{ memo.categories[0] }}</p>
+            <p>{{ memo.categories[1] }}</p>
+            <p>{{ memo.categories[2] }}</p>
+          </div>
+          <div class="icons">
+            <div class="recent-posted-card__card-button">
+              <img src="assets/images/favorite.svg" alt="" />
+              <p>123</p>
+            </div>
+            <div>
+              <a href="https://twitter.com/home" target="blank">
+                <img
+                  class="button button--small-social"
+                  src="assets/images/twitter.svg"
+                  alt=""
+                />
+              </a>
+            </div>
+          </div>
         </div>
-        <div>
-          <img
-            class="button button--small-social"
-            src="assets/images/twitter.svg"
-            alt=""
-          />
-        </div>
       </div>
-    </ng-container>
+    </div>
   </div>
-</div>
+</ng-container>

--- a/src/app/detail-header/detail-header.component.scss
+++ b/src/app/detail-header/detail-header.component.scss
@@ -1,12 +1,18 @@
+@import 'mixins';
 .wrapper {
   max-width: 100%;
 }
 
-.container {
-  border-bottom: 1px solid #fff;
-  padding-bottom: 112px;
-  margin: 112px auto 80px;
-  text-align: center;
+.memo-header {
+  &__thumbnail {
+    border-radius: 8px;
+    width: 120px;
+  }
+  &__contents {
+    @include sm {
+      width: 100%;
+    }
+  }
 }
 
 .memo-category {
@@ -14,6 +20,9 @@
   justify-content: center;
   align-items: center;
   margin-bottom: 24px;
+  @include sm {
+    display: block;
+  }
   & p {
     margin-right: 24px;
   }
@@ -22,6 +31,9 @@
 h1 {
   font-size: 40px;
   margin-bottom: 24px;
+  @include sm {
+    font-size: 20px;
+  }
 }
 
 .icons {

--- a/src/app/detail-header/detail-header.component.ts
+++ b/src/app/detail-header/detail-header.component.ts
@@ -13,12 +13,11 @@ import { MemoService } from '../services/memo.service';
 export class DetailHeaderComponent implements OnInit {
   memoId: string; // MemoServisでmemoIdからMemoをとってくる memoIdのいれもの
   memo$: Observable<Memo>;
-  constructor(private route: ActivatedRoute, private memoService: MemoService) {}
+  constructor(
+    private route: ActivatedRoute,
+    private memoService: MemoService
+  ) {}
 
-
-  // getMemo(): void {
-  //   this.getMemo();
-  // }
   ngOnInit(): void {
     this.memo$ = this.route.paramMap.pipe(
       switchMap((param) => {

--- a/src/app/detail-header/detail-header.component.ts
+++ b/src/app/detail-header/detail-header.component.ts
@@ -1,15 +1,31 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { Memo } from '../interfaces/memo';
+import { MemoService } from '../services/memo.service';
 
 @Component({
   selector: 'app-detail-header',
   templateUrl: './detail-header.component.html',
-  styleUrls: ['./detail-header.component.scss']
+  styleUrls: ['./detail-header.component.scss'],
 })
 export class DetailHeaderComponent implements OnInit {
+  memoId: string; // MemoServisでmemoIdからMemoをとってくる memoIdのいれもの
+  memo$: Observable<Memo>;
+  constructor(private route: ActivatedRoute, private memoService: MemoService) {}
 
-  constructor() { }
 
+  // getMemo(): void {
+  //   this.getMemo();
+  // }
   ngOnInit(): void {
+    this.memo$ = this.route.paramMap.pipe(
+      switchMap((param) => {
+        const id = param.get('id');
+        this.memoId = id;
+        return this.memoService.getMemo(id);
+      })
+    );
   }
-
 }

--- a/src/app/detail-header/detail-header.component.ts
+++ b/src/app/detail-header/detail-header.component.ts
@@ -27,4 +27,7 @@ export class DetailHeaderComponent implements OnInit {
       })
     );
   }
+  like(): void {
+    alert('like!');
+  }
 }

--- a/src/app/edit/edit.component.ts
+++ b/src/app/edit/edit.component.ts
@@ -82,7 +82,7 @@ export class EditComponent implements OnInit {
     const sendData: Omit<
       // sendDataを、uid,title,text,isPublic,categoriesと定義
       Memo,
-      'memoId' | 'createdAt' | 'updatedAt' | 'likeCount' | 'thumbnailUrl'
+      'memoId' | 'createdAt' | 'updatedAt' | 'likeCount' | 'thumbnailUrl' | 'random'
     > = {
       uid: this.authService.uid,
       title: formData.title,

--- a/src/app/edit/edit.component.ts
+++ b/src/app/edit/edit.component.ts
@@ -101,12 +101,4 @@ export class EditComponent implements OnInit {
     });
     this.router.navigateByUrl('/'); // TopComponentのパスにリダイレクトする
   }
-
-  // 投稿に入ってしまう<p>を消去する
-  // Memoのtextから<p>をstriptagを使って消去する
-  removeHtmlTags(): string {
-    const striptags = require('striptags'); // striptagsをrequire()によって読み込む
-    const originalText = this.form.value.text; // editorの本文をoriginalTextの変数に代入
-    return striptags(originalText, null, '\n'); // originalTextからhtmlのタグを削除、残したいタグはなし、第3引数で改行の設定
-  }
 }

--- a/src/app/interfaces/memo.ts
+++ b/src/app/interfaces/memo.ts
@@ -10,5 +10,5 @@ export interface Memo {
   createdAt: firebase.firestore.Timestamp;
   updatedAt: firebase.firestore.Timestamp;
   uid: string;
-  // author: string;
+  random: number;
 }

--- a/src/app/list/list.component.html
+++ b/src/app/list/list.component.html
@@ -1,15 +1,10 @@
 <app-list-header></app-list-header>
 <h2>メモ</h2>
 <div class="list-container">
-  <app-next-card></app-next-card>
-  <app-next-card></app-next-card>
-  <app-next-card></app-next-card>
-  <app-next-card></app-next-card>
-  <app-next-card></app-next-card>
-  <app-next-card></app-next-card>
-  <app-next-card></app-next-card>
-  <app-next-card></app-next-card>
-  <app-next-card></app-next-card>
+  <app-next-card
+    [memo]="memo"
+    *ngFor="let memo of memos$ | async"
+  ></app-next-card>
 </div>
 <div class="next-page-button-container">
   <app-next-page-button></app-next-page-button>

--- a/src/app/list/list.component.ts
+++ b/src/app/list/list.component.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Memo } from '../interfaces/memo';
+import { MemoService } from '../services/memo.service';
 
 @Component({
   selector: 'app-list',
@@ -6,8 +9,8 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./list.component.scss']
 })
 export class ListComponent implements OnInit {
-
-  constructor() { }
+  memos$: Observable<Memo[]> = this.memoService.getlistedMemos();
+  constructor(private memoService: MemoService) { }
 
   ngOnInit(): void {
   }

--- a/src/app/memo-card/memo-card.component.ts
+++ b/src/app/memo-card/memo-card.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Memo } from '../interfaces/memo';
 import { AuthService } from '../services/auth.service';
-// import { RemoveHtmlTagsPipe} from '../remove-html-tags.pipe';
 
 @Component({
   selector: 'app-memo-card',

--- a/src/app/memo-contents/memo-contents.component.html
+++ b/src/app/memo-contents/memo-contents.component.html
@@ -5,23 +5,15 @@
         <div class="memo-contents__article">
           <h2>目次1</h2>
           <div class="">{{ memo.text | removeHtmlTags }}</div>
-          <h2>目次2</h2>
-
-          <h2>目次3</h2>
-
-          <h2>目次4</h2>
-
-          <h2>目次5</h2>
-
-          <h2>目次6</h2>
         </div>
         <div class="memo-contents__under-buttons">
-          <div class="memo-contents__button">
-            <img src="assets/images/favorite.svg" alt="" />123
+          <div class="memo-contents__button" (click)="like()">
+            <img src="assets/images/favorite.svg" alt="" />
+            <p>{{ memo.likeCount }}</p>
           </div>
-          <div class="memo-contents__button memo-contents__button--twitter">
+          <a class="memo-contents__button memo-contents__button--twitter">
             <img src="assets/images/twitter.svg" alt="" />
-          </div>
+          </a>
         </div>
       </div>
     </div>

--- a/src/app/memo-contents/memo-contents.component.html
+++ b/src/app/memo-contents/memo-contents.component.html
@@ -1,90 +1,29 @@
-<div class="memo-contents-container">
-  <div class="memo-contents">
-    <div class="contents-container">
-      <div class="memo-contents__article">
-        <h2>目次1</h2>
-        <div class="memo-contents__text">
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
+<ng-container *ngIf="memo$ | async as memo">
+  <div class="memo-contents-container">
+    <div class="memo-contents">
+      <div class="contents-container">
+        <div class="memo-contents__article">
+          <h2>目次1</h2>
+          <div class="">{{ memo.text | removeHtmlTags }}</div>
+          <h2>目次2</h2>
 
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
+          <h2>目次3</h2>
+
+          <h2>目次4</h2>
+
+          <h2>目次5</h2>
+
+          <h2>目次6</h2>
         </div>
-        <h2>目次2</h2>
-        <div class="memo-contents__text">
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
-        </div>
-        <h2>目次3</h2>
-        <div class="memo-contents__text">
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
-        </div>
-        <h2>目次4</h2>
-        <div class="memo-contents__text">
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
-        </div>
-        <h2>目次5</h2>
-        <div class="memo-contents__text">
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
-        </div>
-        <h2>目次6</h2>
-        <div class="memo-contents__text">
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
-          <p>
-            テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          </p>
-        </div>
-      </div>
-      <div class="memo-contents__under-buttons">
-        <div class="memo-contents__button">
-          <img src="assets/images/favorite.svg" alt="" />123
-        </div>
-        <div class="memo-contents__button memo-contents__button--twitter">
-          <img src="assets/images/twitter.svg" alt="" />
+        <div class="memo-contents__under-buttons">
+          <div class="memo-contents__button">
+            <img src="assets/images/favorite.svg" alt="" />123
+          </div>
+          <div class="memo-contents__button memo-contents__button--twitter">
+            <img src="assets/images/twitter.svg" alt="" />
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
+</ng-container>

--- a/src/app/memo-contents/memo-contents.component.scss
+++ b/src/app/memo-contents/memo-contents.component.scss
@@ -1,3 +1,4 @@
+@import 'mixins';
 .memo-contents-container {
   padding-bottom: 40px;
   border-bottom: 1px solid #fff;

--- a/src/app/memo-contents/memo-contents.component.ts
+++ b/src/app/memo-contents/memo-contents.component.ts
@@ -1,15 +1,30 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { Memo } from '../interfaces/memo';
+import { MemoService } from '../services/memo.service';
 
 @Component({
   selector: 'app-memo-contents',
   templateUrl: './memo-contents.component.html',
-  styleUrls: ['./memo-contents.component.scss']
+  styleUrls: ['./memo-contents.component.scss'],
 })
 export class MemoContentsComponent implements OnInit {
-
-  constructor() { }
+  memoId: string; // MemoServiceでmemoIdからMemoをとってくる(memoIdのいれもの)
+  memo$: Observable<Memo>;
+  constructor(
+    private route: ActivatedRoute,
+    private memoService: MemoService
+  ) {}
 
   ngOnInit(): void {
+    this.memo$ = this.route.paramMap.pipe(
+      switchMap((param) => {
+        const id = param.get('id');
+        this.memoId = id;
+        return this.memoService.getMemo(id);
+      })
+    );
   }
-
 }

--- a/src/app/memo-contents/memo-contents.component.ts
+++ b/src/app/memo-contents/memo-contents.component.ts
@@ -27,4 +27,7 @@ export class MemoContentsComponent implements OnInit {
       })
     );
   }
+  like(): void {
+    alert('like!');
+  }
 }

--- a/src/app/memo/memo.component.html
+++ b/src/app/memo/memo.component.html
@@ -8,7 +8,7 @@
     </div>
     <div class="">
     <app-profile-card class="sp"></app-profile-card>
-    <app-category-card></app-category-card>
+    <app-category-card class="sp"></app-category-card>
     <!-- <app-contents-list></app-contents-list> -->
   <!-- </div> -->
 </div>

--- a/src/app/memo/memo.component.html
+++ b/src/app/memo/memo.component.html
@@ -5,8 +5,8 @@
     <!-- <app-author></app-author> -->
     <!-- <app-coments></app-coments> -->
     <!-- <app-read-next></app-read-next> -->
-  <!-- </div> -->
-  <!-- <div class=""> -->
+    <!-- </div> -->
+    <!-- <div class=""> -->
     <!-- <app-profile-card></app-profile-card> -->
     <!-- <app-category-card></app-category-card> -->
     <!-- <app-contents-list></app-contents-list> -->

--- a/src/app/memo/memo.component.html
+++ b/src/app/memo/memo.component.html
@@ -1,14 +1,14 @@
 <app-detail-header></app-detail-header>
-<div class="memo-conteiner">
-  <div class="main">
-    <app-memo-contents></app-memo-contents>
-    <app-author></app-author>
-    <app-coments></app-coments>
-    <app-read-next></app-read-next>
-  </div>
-  <div class="">
-    <app-profile-card></app-profile-card>
-    <app-category-card></app-category-card>
-    <app-contents-list></app-contents-list>
-  </div>
-</div>
+<!-- <div class="memo-conteiner"> -->
+  <!-- <div class="main"> -->
+    <!-- <app-memo-contents></app-memo-contents> -->
+    <!-- <app-author></app-author> -->
+    <!-- <app-coments></app-coments> -->
+    <!-- <app-read-next></app-read-next> -->
+  <!-- </div> -->
+  <!-- <div class=""> -->
+    <!-- <app-profile-card></app-profile-card> -->
+    <!-- <app-category-card></app-category-card> -->
+    <!-- <app-contents-list></app-contents-list> -->
+  <!-- </div> -->
+<!-- </div> -->

--- a/src/app/memo/memo.component.html
+++ b/src/app/memo/memo.component.html
@@ -4,11 +4,11 @@
     <app-memo-contents></app-memo-contents>
     <app-author></app-author>
     <app-coments></app-coments>
-    <!-- <app-read-next></app-read-next> -->
-    <!-- </div> -->
+    <app-read-next></app-read-next>
+    </div>
     <!-- <div class=""> -->
     <!-- <app-profile-card></app-profile-card> -->
     <!-- <app-category-card></app-category-card> -->
     <!-- <app-contents-list></app-contents-list> -->
-  </div>
+  <!-- </div> -->
 </div>

--- a/src/app/memo/memo.component.html
+++ b/src/app/memo/memo.component.html
@@ -6,9 +6,9 @@
     <app-coments></app-coments>
     <app-read-next></app-read-next>
     </div>
-    <!-- <div class=""> -->
-    <!-- <app-profile-card></app-profile-card> -->
-    <!-- <app-category-card></app-category-card> -->
+    <div class="">
+    <app-profile-card class="sp"></app-profile-card>
+    <app-category-card></app-category-card>
     <!-- <app-contents-list></app-contents-list> -->
   <!-- </div> -->
 </div>

--- a/src/app/memo/memo.component.html
+++ b/src/app/memo/memo.component.html
@@ -2,7 +2,7 @@
 <div class="memo-conteiner">
   <div class="main">
     <app-memo-contents></app-memo-contents>
-    <!-- <app-author></app-author> -->
+    <app-author></app-author>
     <!-- <app-coments></app-coments> -->
     <!-- <app-read-next></app-read-next> -->
     <!-- </div> -->

--- a/src/app/memo/memo.component.html
+++ b/src/app/memo/memo.component.html
@@ -1,7 +1,7 @@
 <app-detail-header></app-detail-header>
-<!-- <div class="memo-conteiner"> -->
-  <!-- <div class="main"> -->
-    <!-- <app-memo-contents></app-memo-contents> -->
+<div class="memo-conteiner">
+  <div class="main">
+    <app-memo-contents></app-memo-contents>
     <!-- <app-author></app-author> -->
     <!-- <app-coments></app-coments> -->
     <!-- <app-read-next></app-read-next> -->
@@ -10,5 +10,5 @@
     <!-- <app-profile-card></app-profile-card> -->
     <!-- <app-category-card></app-category-card> -->
     <!-- <app-contents-list></app-contents-list> -->
-  <!-- </div> -->
-<!-- </div> -->
+  </div>
+</div>

--- a/src/app/memo/memo.component.html
+++ b/src/app/memo/memo.component.html
@@ -3,7 +3,7 @@
   <div class="main">
     <app-memo-contents></app-memo-contents>
     <app-author></app-author>
-    <!-- <app-coments></app-coments> -->
+    <app-coments></app-coments>
     <!-- <app-read-next></app-read-next> -->
     <!-- </div> -->
     <!-- <div class=""> -->

--- a/src/app/memo/memo.component.html
+++ b/src/app/memo/memo.component.html
@@ -9,6 +9,6 @@
     <div class="">
     <app-profile-card class="sp"></app-profile-card>
     <app-category-card class="sp"></app-category-card>
-    <!-- <app-contents-list></app-contents-list> -->
-  <!-- </div> -->
+    <app-contents-list class="sp"></app-contents-list>
+  </div>
 </div>

--- a/src/app/memo/memo.component.scss
+++ b/src/app/memo/memo.component.scss
@@ -1,3 +1,4 @@
+@import 'mixins';
 .memo-conteiner {
   max-width: 1338px;
   display: flex;
@@ -7,5 +8,7 @@
 
 .main {
   margin-right: 45px;
+  @include sm {
+    margin: 0 16px;
+  }
 }
-

--- a/src/app/memo/memo.component.ts
+++ b/src/app/memo/memo.component.ts
@@ -15,7 +15,7 @@ export class MemoComponent implements OnInit {
 
   ngOnInit(): void {
     this.route.paramMap.subscribe(paramMap => {
-      alert(paramMap.get('id')); // memo-routingの:idと紐付いている
+      // alert(paramMap.get('id')); // memo-routingの:idと紐付いている
     });
   }
 

--- a/src/app/memo/memo.module.ts
+++ b/src/app/memo/memo.module.ts
@@ -12,7 +12,6 @@ import { SharedModule } from '../shared/shared.module';
 import { MemoRoutingModule } from './memo-routing.module';
 import { MemoComponent } from './memo.component';
 
-
 @NgModule({
   declarations: [
     MemoComponent,

--- a/src/app/next-card/next-card.component.html
+++ b/src/app/next-card/next-card.component.html
@@ -1,7 +1,7 @@
-<div class="next-card">
-  <div class="card-box">
+<div class="next-card" *ngIf="memo">
+  <div class="card-box" *ngIf="user$ | async as user">
     <div class="next-card__image">
-      <img src="assets/images/read-next-card-image.jpg" alt="" />
+      <img [src]="memo.thumbnailUrl" alt="" />
     </div>
     <div class="next-card__users">
       <div class="inline">
@@ -9,30 +9,29 @@
           <img src="assets/images/profile-image-example.jpg" alt="" />
         </div>
         <div class="next-card__name">
-          <p>UserName</p>
+          <p>{{ user.name }}</p>
         </div>
       </div>
       <div class="next-card__date">
-        <p>2020年12月8日</p>
+        <p>{{ memo.createdAt.toDate() | date: 'yyyy/MM/dd' }}</p>
       </div>
     </div>
     <div class="next-card__title">
-      <p>メモタイトル</p>
+      <p>{{ memo.title }}</p>
     </div>
     <div class="next-card__text">
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum sed
-      sequi eos, natus quidem est praesentium placeat, exercitationem vitae
-      veritatis ut repellendus perspiciatis optio, aut maiores ratione aliquam
-      possimus dolores!
+      {{ memo.text | removeHtmlTags }}
     </div>
     <div class="next-card__buttons">
-      <button>もっとみる</button>
+      <a [routerLink]="['/memo', memo.memoId]" class="more">もっとみる</a>
       <button>
         <div class="next-card__favorite">
           <div>
             <img src="assets/images/favorite.svg" alt="" />
           </div>
-          <div><p>123</p></div>
+          <div>
+            <p>{{ memo.likeCount }}</p>
+          </div>
         </div>
       </button>
     </div>

--- a/src/app/next-card/next-card.component.html
+++ b/src/app/next-card/next-card.component.html
@@ -1,4 +1,4 @@
-<div class="next-card" *ngIf="memo">
+<div class="next-card" *ngIf="memo$ | async as memo">
   <div class="card-box" *ngIf="user$ | async as user">
     <div class="next-card__image">
       <img [src]="memo.thumbnailUrl" alt="" />

--- a/src/app/next-card/next-card.component.html
+++ b/src/app/next-card/next-card.component.html
@@ -1,4 +1,4 @@
-<div class="next-card" *ngIf="memo$ | async as memo">
+<div class="next-card" *ngIf="memo">
   <div class="card-box" *ngIf="user$ | async as user">
     <div class="next-card__image">
       <img [src]="memo.thumbnailUrl" alt="" />

--- a/src/app/next-card/next-card.component.scss
+++ b/src/app/next-card/next-card.component.scss
@@ -1,3 +1,4 @@
+@import 'mixins';
 .next-card {
   box-shadow: 6px 6px 12px #b8b9be, -6px -6px 12px #ffffff;
   border-radius: 8px;
@@ -76,6 +77,9 @@
 }
 .card-box {
   padding: 24px;
+@include sm {
+  margin-bottom: 16px;
+}
 }
 .inline {
   display: inherit;

--- a/src/app/next-card/next-card.component.scss
+++ b/src/app/next-card/next-card.component.scss
@@ -47,6 +47,12 @@
   }
   &__text {
     margin-bottom: 32px;
+    text-align: left;
+    word-break: break-word;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
   &__buttons {
     display: flex;
@@ -77,11 +83,22 @@
 }
 .card-box {
   padding: 24px;
-@include sm {
-  margin-bottom: 16px;
-}
+  @include sm {
+    margin-bottom: 16px;
+  }
 }
 .inline {
   display: inherit;
   align-items: center;
+}
+.more {
+  color: #31344b;
+  padding: 8px 16px;
+  background: #e6e7ee;
+  border: 1px solid #d1d9e6;
+  border-radius: 8px;
+  box-shadow: 6px 6px 12px #b8b9be, -6px -6px 12px #ffffff;
+  &:hover {
+    box-shadow: inset 6px 6px 12px #b8b9be, inset -6px -6px 12px #ffffff;
+  }
 }

--- a/src/app/next-card/next-card.component.ts
+++ b/src/app/next-card/next-card.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
+import { Memo } from '../interfaces/memo';
+import { AuthService } from '../services/auth.service';
 
 @Component({
   selector: 'app-next-card',
@@ -6,7 +8,9 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./next-card.component.scss'],
 })
 export class NextCardComponent implements OnInit {
-  constructor() {}
+  @Input() memo: Memo;
+  user$ = this.authService.user$; // userをauthServiceのuser$と定義
+  constructor(private authService: AuthService) {}
 
   ngOnInit(): void {}
 }

--- a/src/app/next-card/next-card.component.ts
+++ b/src/app/next-card/next-card.component.ts
@@ -13,4 +13,7 @@ export class NextCardComponent implements OnInit {
   constructor(private authService: AuthService) {}
 
   ngOnInit(): void {}
+  like(): void {
+    alert('like!');
+  }
 }

--- a/src/app/next-card/next-card.component.ts
+++ b/src/app/next-card/next-card.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
 import { Memo } from '../interfaces/memo';
 import { AuthService } from '../services/auth.service';
 
@@ -9,6 +10,8 @@ import { AuthService } from '../services/auth.service';
 })
 export class NextCardComponent implements OnInit {
   @Input() memo: Memo;
+  memo$: Observable<Memo>;
+  memoId: string; // MemoServiceでmemoIdからMemoをとってくる(memoIdのいれもの)
   user$ = this.authService.user$; // userをauthServiceのuser$と定義
   constructor(private authService: AuthService) {}
 

--- a/src/app/read-next/read-next.component.html
+++ b/src/app/read-next/read-next.component.html
@@ -2,9 +2,10 @@
   <h3>Read Next</h3>
 
   <div class="read-next__cards">
-    <app-next-card></app-next-card>
-    <app-next-card></app-next-card>
-    <app-next-card></app-next-card>
+    <app-next-card
+      [memo]="memo"
+      *ngFor="let memo of memos$ | async"
+    ></app-next-card>
   </div>
   <div class="more-buttons">
     <button>

--- a/src/app/read-next/read-next.component.scss
+++ b/src/app/read-next/read-next.component.scss
@@ -1,9 +1,13 @@
+@import 'mixins';
 .read-next {
   &__cards {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 24px;
     margin-bottom: 24px;
+    @include sm {
+      display: block;
+    }
   }
 }
 h3 {

--- a/src/app/read-next/read-next.component.ts
+++ b/src/app/read-next/read-next.component.ts
@@ -9,7 +9,7 @@ import { MemoService } from '../services/memo.service';
   styleUrls: ['./read-next.component.scss'],
 })
 export class ReadNextComponent implements OnInit {
-  memos$: Observable<Memo[]> = this.memoService.getRecentMemos();
+  memos$: Observable<Memo[]> = this.memoService.getRelationMemos();
   constructor(private memoService: MemoService) {}
 
   ngOnInit(): void {}

--- a/src/app/read-next/read-next.component.ts
+++ b/src/app/read-next/read-next.component.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Memo } from '../interfaces/memo';
+import { MemoService } from '../services/memo.service';
 
 @Component({
   selector: 'app-read-next',
@@ -6,7 +9,8 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./read-next.component.scss'],
 })
 export class ReadNextComponent implements OnInit {
-  constructor() {}
+  memos$: Observable<Memo[]> = this.memoService.getRecentMemos();
+  constructor(private memoService: MemoService) {}
 
   ngOnInit(): void {}
 }

--- a/src/app/recent-memo/recent-memo.component.ts
+++ b/src/app/recent-memo/recent-memo.component.ts
@@ -12,7 +12,7 @@ import { Observable } from 'rxjs';
   styleUrls: ['./recent-memo.component.scss'],
 })
 export class RecentMemoComponent implements OnInit {
-  memos$: Observable<Memo[]> = this.memoService.getRelationMemos();
+  memos$: Observable<Memo[]> = this.memoService.getRecentMemos();
 
 
 

--- a/src/app/recent-memo/recent-memo.component.ts
+++ b/src/app/recent-memo/recent-memo.component.ts
@@ -12,7 +12,7 @@ import { Observable } from 'rxjs';
   styleUrls: ['./recent-memo.component.scss'],
 })
 export class RecentMemoComponent implements OnInit {
-  memos$: Observable<Memo[]> = this.memoService.getRecentMemos();
+  memos$: Observable<Memo[]> = this.memoService.getRelationMemos();
 
 
 

--- a/src/app/services/memo.service.ts
+++ b/src/app/services/memo.service.ts
@@ -84,6 +84,7 @@ export class MemoService {
     return this.db
       .collection<Memo>(`memos`, (ref) => {
         return ref.orderBy('createdAt', 'desc').limit(3);
+        // return ref.where('isPublic', '==', 'true').orderBy('random').limit(3); // 一旦ランダムで記事を取って来たい
       })
       .valueChanges();
   }

--- a/src/app/services/memo.service.ts
+++ b/src/app/services/memo.service.ts
@@ -84,7 +84,6 @@ export class MemoService {
     return this.db
       .collection<Memo>(`memos`, (ref) => {
         return ref.orderBy('createdAt', 'desc').limit(3);
-        // return ref.where('isPublic', '==', 'true').orderBy('random').limit(3); // 一旦ランダムで記事を取って来たい
       })
       .valueChanges();
   }

--- a/src/app/services/memo.service.ts
+++ b/src/app/services/memo.service.ts
@@ -78,4 +78,8 @@ export class MemoService {
       })
       .valueChanges();
   }
+  // メモのドキュメントを取得
+  getMemo(id: string): Observable<Memo> {
+    return this.db.doc<Memo>(`memos/${id}`).valueChanges();
+  }
 }

--- a/src/app/services/memo.service.ts
+++ b/src/app/services/memo.service.ts
@@ -78,6 +78,16 @@ export class MemoService {
       })
       .valueChanges();
   }
+
+  // 読んでいるメモと関連の高いメモを3件取ってくる
+  getRelationMemos(): Observable<Memo[]> {
+    return this.db
+      .collection<Memo>(`memos`, (ref) => {
+        return ref.orderBy('createdAt', 'desc').limit(3);
+      })
+      .valueChanges();
+  }
+
   // メモのドキュメントを取得
   getMemo(id: string): Observable<Memo> {
     return this.db.doc<Memo>(`memos/${id}`).valueChanges();

--- a/src/app/services/memo.service.ts
+++ b/src/app/services/memo.service.ts
@@ -89,6 +89,13 @@ export class MemoService {
       .valueChanges();
   }
 
+  // リスト表示用にメモを9件取ってくる
+  getlistedMemos(): Observable<Memo[]> {
+    return this.db.collection<Memo>(`memos`, (ref) => {
+      return ref.orderBy('createdAt', 'desc').limit(9);
+    }).valueChanges();
+  }
+
   // メモのドキュメントを取得
   getMemo(id: string): Observable<Memo> {
     return this.db.doc<Memo>(`memos/${id}`).valueChanges();

--- a/src/app/services/memo.service.ts
+++ b/src/app/services/memo.service.ts
@@ -28,7 +28,7 @@ export class MemoService {
     // createMemoの自販機のinputには、memo（Memoの型）とdataUrl（サムネイル画像）が入る（omitの中身は除外する）
     memo: Omit<
       Memo,
-      'memoId' | 'createdAt' | 'updatedAt' | 'likeCount' | 'thumbnailUrl'
+      'memoId' | 'createdAt' | 'updatedAt' | 'likeCount' | 'thumbnailUrl' | 'random'
     >,
     dataUrl: string
   ): Promise<void> {
@@ -42,6 +42,7 @@ export class MemoService {
       likeCount: 0,
       createdAt: firestore.Timestamp.now(),
       updatedAt: firestore.Timestamp.now(),
+      random: Math.random(),
     };
     return this.db.doc(`memos/${id}`).set(resultMemo); // FirestoreのdbのdocのmemosのmemoIdのドキュメントに、resultMemoの中身を入れる(set)
   }
@@ -83,17 +84,19 @@ export class MemoService {
   getRelationMemos(): Observable<Memo[]> {
     return this.db
       .collection<Memo>(`memos`, (ref) => {
-        return ref.orderBy('createdAt', 'desc').limit(3);
-        // return ref.where('isPublic', '==', 'true').orderBy('random').limit(3); // 一旦ランダムで記事を取って来たい
+        // return ref.orderBy('createdAt', 'asc').limit(3);
+        return ref.where('isPublic', '==', 'true').orderBy('random').limit(3); // 一旦ランダムで記事を取って来たい
       })
       .valueChanges();
   }
 
   // リスト表示用にメモを9件取ってくる
   getlistedMemos(): Observable<Memo[]> {
-    return this.db.collection<Memo>(`memos`, (ref) => {
-      return ref.orderBy('createdAt', 'desc').limit(9);
-    }).valueChanges();
+    return this.db
+      .collection<Memo>(`memos`, (ref) => {
+        return ref.orderBy('createdAt', 'desc').limit(9);
+      })
+      .valueChanges();
   }
 
   // メモのドキュメントを取得

--- a/src/app/services/memo.service.ts
+++ b/src/app/services/memo.service.ts
@@ -28,7 +28,12 @@ export class MemoService {
     // createMemoの自販機のinputには、memo（Memoの型）とdataUrl（サムネイル画像）が入る（omitの中身は除外する）
     memo: Omit<
       Memo,
-      'memoId' | 'createdAt' | 'updatedAt' | 'likeCount' | 'thumbnailUrl' | 'random'
+      | 'memoId'
+      | 'createdAt'
+      | 'updatedAt'
+      | 'likeCount'
+      | 'thumbnailUrl'
+      | 'random'
     >,
     dataUrl: string
   ): Promise<void> {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -25,6 +25,7 @@ import { RemoveHtmlTagsPipe } from '../remove-html-tags.pipe';
     MemoCardComponent,
     NextCardComponent,
     NextPageButtonComponent,
+    RemoveHtmlTagsPipe,
   ],
 })
 export class SharedModule {}

--- a/src/app/user-shell/user-shell-routing.module.ts
+++ b/src/app/user-shell/user-shell-routing.module.ts
@@ -8,7 +8,7 @@ const routes: Routes = [
     component: UserShellComponent,
     children: [
       {
-        path: '',
+        path: 'memo',
         loadChildren: () =>
           import('../memo/memo.module').then((m) => m.MemoModule),
       },

--- a/src/app/user-shell/user-shell-routing.module.ts
+++ b/src/app/user-shell/user-shell-routing.module.ts
@@ -10,7 +10,7 @@ const routes: Routes = [
       {
         path: '',
         loadChildren: () =>
-          import('../top/top.module').then((m) => m.TopModule),
+          import('../memo/memo.module').then((m) => m.MemoModule),
       },
       {
         path: '',

--- a/src/app/user-shell/user-shell-routing.module.ts
+++ b/src/app/user-shell/user-shell-routing.module.ts
@@ -13,6 +13,11 @@ const routes: Routes = [
           import('../top/top.module').then((m) => m.TopModule),
       },
       {
+        path: '',
+        loadChildren: () =>
+          import('../top/top.module').then((m) => m.TopModule),
+      },
+      {
         path: 'edit',
         loadChildren: () =>
           import('../edit/edit.module').then((m) => m.EditModule),

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -124,6 +124,10 @@ h4 {
     min-width: 180px;
     padding: 10px;
     text-align: center;
+    @include sm {
+      min-width: 140px;
+      font-size: 14px;
+    }
   }
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -46,6 +46,13 @@ h4 {
   color: #31344b;
 }
 
+// spサイズに関するスタイル
+.sp {
+  @include sm {
+    display: none;
+  }
+}
+
 // Containerに関するスタイル
 .container {
   max-width: 1400px;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -66,6 +66,16 @@ h4 {
     border-bottom: 1px solid #ffffff;
     margin-bottom: 128px;
   }
+  &--memo-header {
+    max-width: 100%;
+    border-bottom: 1px solid #fff;
+    padding-bottom: 112px;
+    margin: 112px auto 80px;
+    @include sm {
+      padding-bottom: 40px;
+      margin: 40px auto;
+    }
+  }
 }
 
 // ボタンに関するスタイル
@@ -297,7 +307,6 @@ h4 {
   padding-right: 56px;
   @include sm {
     padding: 28px;
-
   }
   .guide-text__title {
     margin: 0;


### PR DESCRIPTION
fix #218 

お疲れさまです。下記機能を実装しました。お手数ですがご確認よろしくお願いいたします。

## Detail
- メモ（記事）詳細ページの見た目部分、レスポンシブ対応
- 記事データを取ってきて表示させる
- ページ下部で、次に読む候補をランダムで3件表示

## Image
![screencapture-localhost-4200-memo-DskuoDqRSrTdPpcJSG1Z-2021-02-23-14_00_32](https://user-images.githubusercontent.com/71574248/108804129-c8aefc80-75df-11eb-9352-e27f5d1fc180.png)
![screencapture-localhost-4200-memo-DskuoDqRSrTdPpcJSG1Z-2021-02-23-14_02_13](https://user-images.githubusercontent.com/71574248/108804142-cb115680-75df-11eb-9d08-7a5fbcfb8c21.png)

